### PR TITLE
cleanup temp directory toegevoegd

### DIFF
--- a/easyflex/easyflex.py
+++ b/easyflex/easyflex.py
@@ -185,5 +185,6 @@ class Easyflex:
             self.request_data(module, administratie, parameters, velden)
 
         df = self.cat_modules(module)
+        self.directory.cleanup()
 
         return df


### PR DESCRIPTION
- Belangrijke bug fix: De temp directory dient verwijderd te worden in de laatste stap van ef.query. Wanneer 1 werkmaatschappij meerdere verzoeken voor 1 module achter elkaar stuurt, waarbij sommige verzoeken geen response opleveren, zijn er situaties dat de laatste pickle file wordt geimporteerd (van de vorige request). Dit is fout, dus een veilig stap is om na het uitvragen van alle werkmaatschappijen, de gehele temp directory te verwijderen.
